### PR TITLE
chore(dependabot): Fix PR title and remove version labels

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,7 +5,7 @@ updates:
     schedule:
       interval: "weekly"
     commit-message:
-      prefix: "deps(gomod)"
+      prefix: "chore(gomod)"
     labels:
       - "dependencies"
       - "patch"
@@ -14,7 +14,7 @@ updates:
     schedule:
       interval: "weekly"
     commit-message:
-      prefix: "deps(github-actions)"
+      prefix: "chore(github-actions)"
     labels:
       - "dependencies"
       - "patch"

--- a/.github/workflows/check-pr.yml
+++ b/.github/workflows/check-pr.yml
@@ -15,6 +15,20 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  fix_dependabot_labels:
+    runs-on: ubuntu-latest
+    if: github.actor == 'dependabot[bot]'
+    permissions:
+      pull-requests: write
+      checks: write
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions-ecosystem/action-remove-labels@v1
+        with:
+          labels: |
+            major
+            minor
+
   check_semver_labels:
     name: Check Semver labels
     if: github.base_ref == 'main'


### PR DESCRIPTION
Dependabot automatically adds `major`, `minor` and `patch` labels if they exist, corresponding to the semver level of the dependency update.

This breaks our releases. Dependabot updates should always be `patch` level.