### PR TITLE
Fix: example provider name, bump version

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -37,9 +37,9 @@ The token will be printed in the console. This token will grant the same level o
 # Configure the SemaphoreUI provider using required_providers.
 terraform {
   required_providers {
-    semaphore = {
+    semaphoreui = {
       source  = "CruGlobal/semaphoreui"
-      version = "~> 1.0.0"
+      version = "~> 1.3.0"
     }
   }
 }


### PR DESCRIPTION
- Update the `required_providers` name to match the below `provider` block
- Bump example version