### PR TITLE
fix: provider docs used incorrect provider name

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -37,9 +37,9 @@ The token will be printed in the console. This token will grant the same level o
 # Configure the SemaphoreUI provider using required_providers.
 terraform {
   required_providers {
-    semaphore = {
+    semaphoreui = {
       source  = "CruGlobal/semaphoreui"
-      version = "~> 1.0.0"
+      version = "~> 1.3.1"
     }
   }
 }

--- a/examples/provider/provider.tf
+++ b/examples/provider/provider.tf
@@ -1,9 +1,9 @@
 # Configure the SemaphoreUI provider using required_providers.
 terraform {
   required_providers {
-    semaphore = {
+    semaphoreui = {
       source  = "CruGlobal/semaphoreui"
-      version = "~> 1.0.0"
+      version = "~> 1.3.1"
     }
   }
 }


### PR DESCRIPTION
* Update the `required_providers` name to match the below `provider` block and bump version.

Thanks @guyzsarun