### PR TITLE
chore: bump golang to 1.24.1

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,2 +1,3 @@
+golang 1.24.1
 terraform 1.11.3
 pre-commit 4.2.0

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module terraform-provider-semaphoreui
 
-go 1.22.8
+go 1.24.1
 
 require (
 	github.com/adhocore/gronx v1.19.5

--- a/tools/go.mod
+++ b/tools/go.mod
@@ -1,6 +1,6 @@
 module tools
 
-go 1.22.7
+go 1.24.1
 
 require github.com/hashicorp/terraform-plugin-docs v0.19.4
 


### PR DESCRIPTION
Bump golang to `1.24.1`