### PR TITLE
feat: Add `tls_skip_verify` provider option

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,11 +2,15 @@
 # See https://pre-commit.com/hooks.html for more hooks
 repos:
   - repo: https://github.com/golangci/golangci-lint
-    rev: v1.62.2
+    rev: v2.1.6
     hooks:
       - id: golangci-lint
         args:
           - "--tests=false"
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v5.0.0
+    hooks:
+      - id: end-of-file-fixer
   - repo: https://github.com/antonbabenko/pre-commit-terraform
     rev: v1.96.2
     hooks:

--- a/docs/index.md
+++ b/docs/index.md
@@ -9,7 +9,7 @@ description: |-
   
   fetch("/api/user/tokens", {
     method: "POST",
-    headers: {'Content-Type': 'application/json'}, 
+    headers: {'Content-Type': 'application/json'},
     body: JSON.stringify({})
   }).then(res => res.json()).then(data => console.log("api_token = " + data.id));
   
@@ -25,7 +25,7 @@ You can generate a Semaphore API token by logging into Semaphore, opening the br
 ```javascript
 fetch("/api/user/tokens", {
   method: "POST",
-  headers: {'Content-Type': 'application/json'}, 
+  headers: {'Content-Type': 'application/json'},
   body: JSON.stringify({})
 }).then(res => res.json()).then(data => console.log("api_token = " + data.id));
 ```
@@ -39,7 +39,7 @@ terraform {
   required_providers {
     semaphoreui = {
       source  = "CruGlobal/semaphoreui"
-      version = "~> 1.3.1"
+      version = "~> 1.0"
     }
   }
 }
@@ -63,3 +63,4 @@ provider "semaphoreui" {
 - `path` (String) SemaphoreUI API base path. This can also be defined by the `SEMAPHOREUI_PATH` environment variable. Default: `/api`.
 - `port` (Number) SemaphoreUI API port. This can also be defined by the `SEMAPHOREUI_PORT` environment variable. Default: `3000`.
 - `protocol` (String) SemaphoreUI API protocol. This can also be defined by the `SEMAPHOREUI_PROTOCOL` environment variable. Must be one of `http` or `https`. Default: `https`.
+- `tls_skip_verify` (Boolean) Skip TLS verification for the SemaphoreUI API when using https. This can also be defined by the `SEMAPHOREUI_TLS_SKIP_VERIFY` environment variable.  Default: `false`.

--- a/examples/provider/provider.tf
+++ b/examples/provider/provider.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     semaphoreui = {
       source  = "CruGlobal/semaphoreui"
-      version = "~> 1.3.1"
+      version = "~> 1.0"
     }
   }
 }


### PR DESCRIPTION
Added a `tls_skip_verify` option to ignore invalid certificates on https requests. This should only be used for testing and not in production as it could allow a machine-in-the-middle attack.

Fixes #41 