### PR TITLE
fix: Fix project environment secret updates

### DIFF
--- a/internal/provider/project_environment_resource.go
+++ b/internal/provider/project_environment_resource.go
@@ -145,6 +145,12 @@ func convertProjectEnvironmentModelToEnvironmentRequest(ctx context.Context, env
 					if !secret.Name.Equal(prevSecret.Name) {
 						modelSecret.Name = secret.Name.ValueString()
 					}
+					if !secret.Value.Equal(prevSecret.Value) {
+						modelSecret.Secret = secret.Value.ValueString()
+					}
+					if !secret.Type.Equal(prevSecret.Type) {
+						modelSecret.Type = secret.Type.ValueString()
+					}
 				}
 			}
 		}


### PR DESCRIPTION
consider include the new secret value when marking an existing secret update
Without this a secret value is never updated

Closes https://github.com/semaphoreui/terraform-provider-semaphore/issues/8


```
PUT /api/project/1/environment/2 HTTP/1.1
Host: 127.0.0.1:3000
User-Agent: Go-http-client/1.1
Content-Length: 3924
Accept: application/json
Accept: text/plain; charset=utf-8
Authorization: Bearer 7qxmya0tumu6ovaztuoho6po2qqk395ow30mvnf5ucw=
Content-Type: application/json
Accept-Encoding: gzip

{"env":"{\"VAULT_ADDR\":\"http://127.0.0.1:8200\",\"VAULT_APPROLE_AUTH_PATH\":\"approle/techops-test-dev\",\"VAULT_SECRET_BASE_PATH\":\"dev\",\"VAULT_SECRET_MOUNT_POINT\":\"kv-techops\"}","id":2,"json":"{}","name":"techops-test-repo1-dev-secrets","project_id":1,"secrets":[{"id":4,"name":"VAULT_APPROLE_ROLE_ID","type":"env"},{"id":5,"name":"VAULT_APPROLE_SECRET_ID","type":"env"},{"id":6,"name":"SSH_KEYS_GITLAB","type":"env"},{"id":7,"name":"SSH_KEYS_SERVER","operation":"update","secret":"-----BEGIN OPENSSH PRIVATE KEY-----\nredacted\n-----END OPENSSH PRIVATE KEY-----\n","type":"env"}]}


HTTP/1.1 204 No Content
Content-Type: application/json
Date: Thu, 11 Dec 2025 11:20:55 GMT
```