### PR TITLE
feat: add OpenTofu workspace inventory support

### DIFF
--- a/docs/resources/project_inventory.md
+++ b/docs/resources/project_inventory.md
@@ -3,12 +3,12 @@
 page_title: "semaphoreui_project_inventory Resource - semaphoreui"
 subcategory: ""
 description: |-
-  The project inventory resource allows you to define the Ansible inventory or a Terraform/OpenTofu workspace for a project.  Only one of the inventory types (static, static_yaml, file or terraform_workspace) can be defined per inventory.
+  The project inventory resource allows you to define the Ansible inventory or a Terraform/OpenTofu workspace for a project.  Only one of the inventory types (static, static_yaml, file, terraform_workspace or tofu_workspace) can be defined per inventory.
 ---
 
 # semaphoreui_project_inventory (Resource)
 
-The project inventory resource allows you to define the Ansible inventory or a Terraform/OpenTofu workspace for a project.  Only one of the inventory types (`static`, `static_yaml`, `file` or `terraform_workspace`) can be defined per inventory.
+The project inventory resource allows you to define the Ansible inventory or a Terraform/OpenTofu workspace for a project.  Only one of the inventory types (`static`, `static_yaml`, `file`, `terraform_workspace` or `tofu_workspace`) can be defined per inventory.
 
 ## Example Usage
 
@@ -72,12 +72,22 @@ resource "semaphoreui_project_inventory" "file" {
   }
 }
 
-# Terraform/OpenTofu Workspace Inventory Example
+# Terraform Workspace Inventory Example
 resource "semaphoreui_project_inventory" "terraform" {
   project_id = semaphoreui_project.project.id
   name       = "Terraform Workspace Inventory"
   ssh_key_id = semaphoreui_project_key.none.id
   terraform_workspace = {
+    workspace = "workspace-name"
+  }
+}
+
+# OpenTofu Workspace Inventory Example
+resource "semaphoreui_project_inventory" "tofu" {
+  project_id = semaphoreui_project.project.id
+  name       = "OpenTofu Workspace Inventory"
+  ssh_key_id = semaphoreui_project_key.none.id
+  tofu_workspace = {
     workspace = "workspace-name"
   }
 }
@@ -98,6 +108,7 @@ resource "semaphoreui_project_inventory" "terraform" {
 - `static` (Attributes) Static Inventory. (see [below for nested schema](#nestedatt--static))
 - `static_yaml` (Attributes) Static YAML Inventory. (see [below for nested schema](#nestedatt--static_yaml))
 - `terraform_workspace` (Attributes) Terraform Workspace. (see [below for nested schema](#nestedatt--terraform_workspace))
+- `tofu_workspace` (Attributes) OpenTofu Workspace. (see [below for nested schema](#nestedatt--tofu_workspace))
 
 ### Read-Only
 
@@ -146,6 +157,14 @@ Optional:
 Required:
 
 - `workspace` (String) The Terraform workspace name.
+
+
+<a id="nestedatt--tofu_workspace"></a>
+### Nested Schema for `tofu_workspace`
+
+Required:
+
+- `workspace` (String) The OpenTofu workspace name.
 
 ## Import
 

--- a/examples/resources/semaphoreui_project_inventory/resource.tf
+++ b/examples/resources/semaphoreui_project_inventory/resource.tf
@@ -57,12 +57,22 @@ resource "semaphoreui_project_inventory" "file" {
   }
 }
 
-# Terraform/OpenTofu Workspace Inventory Example
+# Terraform Workspace Inventory Example
 resource "semaphoreui_project_inventory" "terraform" {
   project_id = semaphoreui_project.project.id
   name       = "Terraform Workspace Inventory"
   ssh_key_id = semaphoreui_project_key.none.id
   terraform_workspace = {
+    workspace = "workspace-name"
+  }
+}
+
+# OpenTofu Workspace Inventory Example
+resource "semaphoreui_project_inventory" "tofu" {
+  project_id = semaphoreui_project.project.id
+  name       = "OpenTofu Workspace Inventory"
+  ssh_key_id = semaphoreui_project_key.none.id
+  tofu_workspace = {
     workspace = "workspace-name"
   }
 }

--- a/internal/provider/project_inventory_resource.go
+++ b/internal/provider/project_inventory_resource.go
@@ -11,7 +11,6 @@ import (
 	"terraform-provider-semaphoreui/semaphoreui/models"
 )
 
-// Ensure the implementation satisfies the expected interfaces.
 var (
 	_ resource.Resource                     = &projectInventoryResource{}
 	_ resource.ResourceWithConfigure        = &projectInventoryResource{}
@@ -44,12 +43,10 @@ func (r *projectInventoryResource) Configure(_ context.Context, req resource.Con
 	r.client = client
 }
 
-// Metadata returns the resource type name.
 func (r *projectInventoryResource) Metadata(_ context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
 	resp.TypeName = req.ProviderTypeName + "_project_inventory"
 }
 
-// Schema defines the schema for the resource.
 func (r *projectInventoryResource) Schema(ctx context.Context, _ resource.SchemaRequest, resp *resource.SchemaResponse) {
 	resp.Schema = ProjectInventorySchema().GetResource(ctx)
 }
@@ -61,6 +58,7 @@ func (r *projectInventoryResource) ConfigValidators(ctx context.Context) []resou
 			path.MatchRoot("static_yaml"),
 			path.MatchRoot("file"),
 			path.MatchRoot("terraform_workspace"),
+			path.MatchRoot("tofu_workspace"),
 		),
 	}
 }
@@ -90,6 +88,9 @@ func convertProjectInventoryModelToInventoryRequest(inventory ProjectInventoryMo
 	} else if inventory.TerraformWorkspace != nil {
 		model.Type = ProjectInventoryTerraformWorkspace
 		model.Inventory = inventory.TerraformWorkspace.Workspace.ValueString()
+	} else if inventory.TofuWorkspace != nil {
+		model.Type = ProjectInventoryTofuWorkspace
+		model.Inventory = inventory.TofuWorkspace.Workspace.ValueString()
 	}
 
 	return &model
@@ -140,11 +141,14 @@ func convertInventoryResponseToProjectInventoryModel(inventory *models.Inventory
 		model.TerraformWorkspace = &ProjectInventoryTerraformWorkspaceModel{
 			Workspace: types.StringValue(inventory.Inventory),
 		}
+	case ProjectInventoryTofuWorkspace:
+		model.TofuWorkspace = &ProjectInventoryTofuWorkspaceModel{
+			Workspace: types.StringValue(inventory.Inventory),
+		}
 	}
 	return model
 }
 
-// Create creates the resource and sets the initial Terraform state.
 func (r *projectInventoryResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
 	var plan ProjectInventoryModel
 	diags := req.Plan.Get(ctx, &plan)
@@ -166,7 +170,6 @@ func (r *projectInventoryResource) Create(ctx context.Context, req resource.Crea
 	}
 	plan = convertInventoryResponseToProjectInventoryModel(response.Payload)
 
-	// Set state to fully populated data
 	diags = resp.State.Set(ctx, &plan)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
@@ -174,9 +177,7 @@ func (r *projectInventoryResource) Create(ctx context.Context, req resource.Crea
 	}
 }
 
-// Read refreshes the Terraform state with the latest data.
 func (r *projectInventoryResource) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
-	// Get current state
 	var state ProjectInventoryModel
 	diags := req.State.Get(ctx, &state)
 	resp.Diagnostics.Append(diags...)
@@ -197,7 +198,6 @@ func (r *projectInventoryResource) Read(ctx context.Context, req resource.ReadRe
 	}
 	state = convertInventoryResponseToProjectInventoryModel(response.Payload)
 
-	// Set refreshed state
 	diags = resp.State.Set(ctx, &state)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
@@ -205,9 +205,7 @@ func (r *projectInventoryResource) Read(ctx context.Context, req resource.ReadRe
 	}
 }
 
-// Update updates the resource and sets the updated Terraform state on success.
 func (r *projectInventoryResource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
-	// Retrieve values from plan
 	var plan ProjectInventoryModel
 	diags := req.Plan.Get(ctx, &plan)
 	resp.Diagnostics.Append(diags...)
@@ -228,7 +226,6 @@ func (r *projectInventoryResource) Update(ctx context.Context, req resource.Upda
 		return
 	}
 
-	// Fetch updated values as PutProjectProjectIDInventoryInventoryID does not return updated project inventory
 	response, err := r.client.Project.GetProjectProjectIDInventoryInventoryID(&project.GetProjectProjectIDInventoryInventoryIDParams{
 		ProjectID:   plan.ProjectID.ValueInt64(),
 		InventoryID: plan.ID.ValueInt64(),
@@ -242,7 +239,6 @@ func (r *projectInventoryResource) Update(ctx context.Context, req resource.Upda
 	}
 	plan = convertInventoryResponseToProjectInventoryModel(response.Payload)
 
-	// Update resource state with updated project
 	diags = resp.State.Set(ctx, plan)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
@@ -250,9 +246,7 @@ func (r *projectInventoryResource) Update(ctx context.Context, req resource.Upda
 	}
 }
 
-// Delete deletes the resource and removes the Terraform state on success.
 func (r *projectInventoryResource) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
-	// Retrieve values from state
 	var state ProjectInventoryModel
 	diags := req.State.Get(ctx, &state)
 	resp.Diagnostics.Append(diags...)
@@ -260,7 +254,6 @@ func (r *projectInventoryResource) Delete(ctx context.Context, req resource.Dele
 		return
 	}
 
-	// Delete existing resource
 	_, err := r.client.Project.DeleteProjectProjectIDInventoryInventoryID(&project.DeleteProjectProjectIDInventoryInventoryIDParams{
 		ProjectID:   state.ProjectID.ValueInt64(),
 		InventoryID: state.ID.ValueInt64(),

--- a/internal/provider/project_inventory_schema.go
+++ b/internal/provider/project_inventory_schema.go
@@ -24,6 +24,7 @@ type (
 		StaticYaml         *ProjectInventoryStaticYamlModel         `tfsdk:"static_yaml"`
 		File               *ProjectInventoryFileModel               `tfsdk:"file"`
 		TerraformWorkspace *ProjectInventoryTerraformWorkspaceModel `tfsdk:"terraform_workspace"`
+		TofuWorkspace      *ProjectInventoryTofuWorkspaceModel      `tfsdk:"tofu_workspace"`
 	}
 
 	ProjectInventoryStaticModel struct {
@@ -45,6 +46,10 @@ type (
 	ProjectInventoryTerraformWorkspaceModel struct {
 		Workspace types.String `tfsdk:"workspace"`
 	}
+
+	ProjectInventoryTofuWorkspaceModel struct {
+		Workspace types.String `tfsdk:"workspace"`
+	}
 )
 
 const (
@@ -52,6 +57,7 @@ const (
 	ProjectInventoryStaticYaml         string = "static-yaml"
 	ProjectInventoryFile               string = "file"
 	ProjectInventoryTerraformWorkspace string = "terraform-workspace"
+	ProjectInventoryTofuWorkspace      string = "tofu-workspace"
 )
 
 func ProjectInventorySchema() superschema.Schema {
@@ -60,7 +66,7 @@ func ProjectInventorySchema() superschema.Schema {
 			MarkdownDescription: "The project inventory",
 		},
 		Resource: superschema.SchemaDetails{
-			MarkdownDescription: "resource allows you to define the Ansible inventory or a Terraform/OpenTofu workspace for a project.  Only one of the inventory types (`static`, `static_yaml`, `file` or `terraform_workspace`) can be defined per inventory.",
+			MarkdownDescription: "resource allows you to define the Ansible inventory or a Terraform/OpenTofu workspace for a project.  Only one of the inventory types (`static`, `static_yaml`, `file`, `terraform_workspace` or `tofu_workspace`) can be defined per inventory.",
 		},
 		DataSource: superschema.SchemaDetails{
 			MarkdownDescription: "data source allows you to read the Ansible inventory or a Terraform/OpenTofu workspace for a project.",
@@ -213,7 +219,6 @@ func ProjectInventorySchema() superschema.Schema {
 						Resource: &schemaR.StringAttribute{
 							Required: true,
 							Validators: []validator.String{
-								// Only relative paths are allowed
 								stringvalidator.RegexMatches(
 									regexp.MustCompile(`^[^/].*$`),
 									"must be a relative path (path/to/inventory)",
@@ -262,6 +267,30 @@ func ProjectInventorySchema() superschema.Schema {
 					"workspace": superschema.StringAttribute{
 						Common: &schemaR.StringAttribute{
 							MarkdownDescription: "The Terraform workspace name.",
+						},
+						Resource: &schemaR.StringAttribute{
+							Required: true,
+						},
+						DataSource: &schemaD.StringAttribute{
+							Computed: true,
+						},
+					},
+				},
+			},
+			"tofu_workspace": superschema.SingleNestedAttribute{
+				Common: &schemaR.SingleNestedAttribute{
+					MarkdownDescription: "OpenTofu Workspace.",
+				},
+				Resource: &schemaR.SingleNestedAttribute{
+					Optional: true,
+				},
+				DataSource: &schemaD.SingleNestedAttribute{
+					Computed: true,
+				},
+				Attributes: map[string]superschema.Attribute{
+					"workspace": superschema.StringAttribute{
+						Common: &schemaR.StringAttribute{
+							MarkdownDescription: "The OpenTofu workspace name.",
 						},
 						Resource: &schemaR.StringAttribute{
 							Required: true,

--- a/internal/provider/project_inventory_tofu_resource_test.go
+++ b/internal/provider/project_inventory_tofu_resource_test.go
@@ -1,0 +1,121 @@
+package provider
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+)
+
+func testAccProjectProjectInventoryTofuWorkspaceConfig(nameSuffix string, workspace string) string {
+	return testAccProjectInventoryConfig(nameSuffix, fmt.Sprintf(`
+  tofu_workspace = {
+    workspace = "%[1]s"
+  }
+`, workspace))
+}
+
+func TestAcc_ProjectInventoryResource_basicTofuWorkspace(t *testing.T) {
+	nameSuffix := acctest.RandString(8)
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccProjectProjectInventoryTofuWorkspaceConfig(nameSuffix, "name"),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccProjectInventoryExists("semaphoreui_project_inventory.test", ProjectInventoryTofuWorkspace),
+					resource.TestCheckResourceAttr("semaphoreui_project_inventory.test", "name", fmt.Sprintf("Test %s", nameSuffix)),
+					resource.TestCheckResourceAttr("semaphoreui_project_inventory.test", "tofu_workspace.%", "1"),
+					resource.TestCheckResourceAttr("semaphoreui_project_inventory.test", "tofu_workspace.workspace", "name"),
+					resource.TestCheckNoResourceAttr("semaphoreui_project_inventory.test", "static"),
+					resource.TestCheckNoResourceAttr("semaphoreui_project_inventory.test", "static_yaml"),
+					resource.TestCheckNoResourceAttr("semaphoreui_project_inventory.test", "file"),
+					resource.TestCheckNoResourceAttr("semaphoreui_project_inventory.test", "terraform_workspace"),
+					resource.TestCheckResourceAttrSet("semaphoreui_project_inventory.test", "id"),
+					resource.TestCheckResourceAttrSet("semaphoreui_project_inventory.test", "project_id"),
+					resource.TestCheckResourceAttrSet("semaphoreui_project_inventory.test", "ssh_key_id"),
+				),
+			},
+			{
+				ResourceName:      "semaphoreui_project_inventory.test",
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateIdFunc: testAccProjectInventoryImportID("semaphoreui_project_inventory.test"),
+			},
+			{
+				Config: testAccProjectProjectInventoryTofuWorkspaceConfig(nameSuffix, "testing"),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccProjectInventoryExists("semaphoreui_project_inventory.test", ProjectInventoryTofuWorkspace),
+					resource.TestCheckResourceAttr("semaphoreui_project_inventory.test", "name", fmt.Sprintf("Test %s", nameSuffix)),
+					resource.TestCheckResourceAttr("semaphoreui_project_inventory.test", "tofu_workspace.%", "1"),
+					resource.TestCheckResourceAttr("semaphoreui_project_inventory.test", "tofu_workspace.workspace", "testing"),
+					resource.TestCheckNoResourceAttr("semaphoreui_project_inventory.test", "static"),
+					resource.TestCheckNoResourceAttr("semaphoreui_project_inventory.test", "static_yaml"),
+					resource.TestCheckNoResourceAttr("semaphoreui_project_inventory.test", "file"),
+					resource.TestCheckNoResourceAttr("semaphoreui_project_inventory.test", "terraform_workspace"),
+					resource.TestCheckResourceAttrSet("semaphoreui_project_inventory.test", "id"),
+					resource.TestCheckResourceAttrSet("semaphoreui_project_inventory.test", "project_id"),
+					resource.TestCheckResourceAttrSet("semaphoreui_project_inventory.test", "ssh_key_id"),
+				),
+			},
+			{
+				Config: testAccProjectInventoryEmptyConfig(nameSuffix, ""),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccResourceNotExists("semaphoreui_project_inventory.test"),
+				),
+			},
+		},
+	})
+}
+
+func TestAcc_ProjectInventoryResource_updateTypeToTofuWorkspace(t *testing.T) {
+	nameSuffix := acctest.RandString(8)
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccProjectProjectInventoryFileConfig(nameSuffix, "path/to/inventory"),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccProjectInventoryExists("semaphoreui_project_inventory.test", ProjectInventoryFile),
+					resource.TestCheckResourceAttr("semaphoreui_project_inventory.test", "name", fmt.Sprintf("Test %s", nameSuffix)),
+					resource.TestCheckResourceAttr("semaphoreui_project_inventory.test", "file.%", "3"),
+					resource.TestCheckResourceAttr("semaphoreui_project_inventory.test", "file.path", "path/to/inventory"),
+					resource.TestCheckNoResourceAttr("semaphoreui_project_inventory.test", "file.become_key_id"),
+					resource.TestCheckNoResourceAttr("semaphoreui_project_inventory.test", "file.repository_id"),
+					resource.TestCheckNoResourceAttr("semaphoreui_project_inventory.test", "static"),
+					resource.TestCheckNoResourceAttr("semaphoreui_project_inventory.test", "static_yaml"),
+					resource.TestCheckNoResourceAttr("semaphoreui_project_inventory.test", "terraform_workspace"),
+					resource.TestCheckNoResourceAttr("semaphoreui_project_inventory.test", "tofu_workspace"),
+					resource.TestCheckResourceAttrSet("semaphoreui_project_inventory.test", "id"),
+					resource.TestCheckResourceAttrSet("semaphoreui_project_inventory.test", "project_id"),
+					resource.TestCheckResourceAttrSet("semaphoreui_project_inventory.test", "ssh_key_id"),
+				),
+			},
+			{
+				Config: testAccProjectProjectInventoryTofuWorkspaceConfig(nameSuffix, "testing"),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccProjectInventoryExists("semaphoreui_project_inventory.test", ProjectInventoryTofuWorkspace),
+					resource.TestCheckResourceAttr("semaphoreui_project_inventory.test", "name", fmt.Sprintf("Test %s", nameSuffix)),
+					resource.TestCheckResourceAttr("semaphoreui_project_inventory.test", "tofu_workspace.%", "1"),
+					resource.TestCheckResourceAttr("semaphoreui_project_inventory.test", "tofu_workspace.workspace", "testing"),
+					resource.TestCheckNoResourceAttr("semaphoreui_project_inventory.test", "static"),
+					resource.TestCheckNoResourceAttr("semaphoreui_project_inventory.test", "static_yaml"),
+					resource.TestCheckNoResourceAttr("semaphoreui_project_inventory.test", "file"),
+					resource.TestCheckNoResourceAttr("semaphoreui_project_inventory.test", "terraform_workspace"),
+					resource.TestCheckResourceAttrSet("semaphoreui_project_inventory.test", "id"),
+					resource.TestCheckResourceAttrSet("semaphoreui_project_inventory.test", "project_id"),
+					resource.TestCheckResourceAttrSet("semaphoreui_project_inventory.test", "ssh_key_id"),
+				),
+			},
+			{
+				Config: testAccProjectInventoryEmptyConfig(nameSuffix, ""),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccResourceNotExists("semaphoreui_project_inventory.test"),
+				),
+			},
+		},
+	})
+}


### PR DESCRIPTION
## Summary

- add `tofu_workspace` support to `semaphoreui_project_inventory`
- map `tofu_workspace` to the Semaphore inventory type `tofu-workspace`
- add acceptance coverage for OpenTofu workspace inventory creation/import and type updates
- update resource docs and examples to include `tofu_workspace`

## Why

Semaphore itself distinguishes `terraform-workspace` and `tofu-workspace`, but the provider currently only models `terraform_workspace`.

That prevents fully declarative OpenTofu inventory automation even though the Semaphore UI and API already support OpenTofu workspaces as a separate inventory type.

## Changes

- add `ProjectInventoryTofuWorkspaceModel`
- extend `ProjectInventoryModel` with `tofu_workspace`
- add `ProjectInventoryTofuWorkspace = "tofu-workspace"`
- allow `tofu_workspace` in project inventory config validation
- convert `tofu_workspace` to/from the Semaphore API model
- add acceptance tests for:
  - basic `tofu_workspace` inventory lifecycle
  - updating an inventory from `file` to `tofu_workspace`
- update docs and examples

## Validation

Validated locally against a live Semaphore instance:

- patched provider loaded through local OpenTofu dev overrides
- Dockhand Semaphore environment planned successfully with the patched provider
- a temporary `tofu_workspace` inventory planned correctly in Dockhand
- acceptance tests passed:

```text
=== RUN   TestAcc_ProjectInventoryResource_basicTofuWorkspace
--- PASS: TestAcc_ProjectInventoryResource_basicTofuWorkspace
=== RUN   TestAcc_ProjectInventoryResource_updateTypeToTofuWorkspace
--- PASS: TestAcc_ProjectInventoryResource_updateTypeToTofuWorkspace
PASS