### PR TITLE
feat: add task_params on project_template and project_integration (closes #53)

### DIFF
--- a/api-docs.yml
+++ b/api-docs.yml
@@ -646,7 +646,7 @@ definitions:
         type: string
       searchable:
         type: boolean
-      params:
+      task_params:
         $ref: '#/definitions/TaskPrams'
 
   IntegrationExtractValueRequest:
@@ -955,6 +955,8 @@ definitions:
         type: integer
       autorun:
         type: boolean
+      task_params:
+        $ref: '#/definitions/TaskPrams'
 
   Template:
     type: object
@@ -1019,6 +1021,8 @@ definitions:
         type: array
         items:
           $ref: "#/definitions/TemplateVault"
+      task_params:
+        $ref: '#/definitions/TaskPrams'
 
   TemplateSurveyVar:
     type: object

--- a/docs/data-sources/project_integration.md
+++ b/docs/data-sources/project_integration.md
@@ -44,4 +44,40 @@ data "semaphoreui_project_integration" "by_name" {
 - `auth_method` (String) How incoming requests are authenticated. Known values: `none`, `token`, `hmac`, `github`, `gitlab`, `bitbucket`. Defaults to `none`.
 - `auth_secret_id` (Number) The project key ID that holds the credential used to verify incoming requests (relevant when `auth_method` is `token` or `hmac`).
 - `searchable` (Boolean) Whether to index this integration's task history for search.
+- `task_params` (Attributes) Default task parameters applied when this template or integration runs a task. (see [below for nested schema](#nestedatt--task_params))
 - `template_id` (Number) The template ID that this integration triggers when invoked.
+
+<a id="nestedatt--task_params"></a>
+### Nested Schema for `task_params`
+
+Read-Only:
+
+- `ansible` (Attributes) Ansible-specific task parameters. Use this when `app` is `ansible`. (see [below for nested schema](#nestedatt--task_params--ansible))
+- `arguments` (String) JSON-encoded array of extra command-line arguments passed to the task runner (e.g. `"[\"-vvv\"]"`).
+- `environment` (String) JSON-encoded object of environment variables exposed to the task.
+- `git_branch` (String) Override the repository branch checked out for this task.
+- `message` (String) Optional commit-style message recorded with each task run.
+- `terraform` (Attributes) Terraform / OpenTofu-specific task parameters. Use this when `app` is `terraform` or `tofu`. (see [below for nested schema](#nestedatt--task_params--terraform))
+
+<a id="nestedatt--task_params--ansible"></a>
+### Nested Schema for `task_params.ansible`
+
+Read-Only:
+
+- `debug` (Boolean) Run Ansible with `-vvvv` debug output.
+- `diff` (Boolean) Show file diffs for changes Ansible makes (`--diff`).
+- `dry_run` (Boolean) Run Ansible in check mode (`--check`).
+- `limit` (List of String) Ansible hosts to limit the run to (`--limit`).
+- `skip_tags` (List of String) Ansible tags to skip (`--skip-tags`).
+- `tags` (List of String) Ansible tags to run (`--tags`).
+
+
+<a id="nestedatt--task_params--terraform"></a>
+### Nested Schema for `task_params.terraform`
+
+Read-Only:
+
+- `auto_approve` (Boolean) Run with `-auto-approve`.
+- `destroy` (Boolean) Run a destroy (`terraform destroy` / `tofu destroy`).
+- `plan` (Boolean) Run plan-only (no apply).
+- `upgrade` (Boolean) Pass `-upgrade` to `terraform init` / `tofu init`.

--- a/docs/data-sources/project_template.md
+++ b/docs/data-sources/project_template.md
@@ -53,6 +53,7 @@ data "semaphoreui_project_template" "build" {
 - `repository_id` (Number) The repository ID that the template uses.
 - `suppress_success_alerts` (Boolean) Suppress success alerts.
 - `survey_vars` (Attributes List) Survey variables. (see [below for nested schema](#nestedatt--survey_vars))
+- `task_params` (Attributes) Default task parameters applied when this template or integration runs a task. (see [below for nested schema](#nestedatt--task_params))
 - `vaults` (Attributes List) Ansible Vault Passwords. (see [below for nested schema](#nestedatt--vaults))
 - `view_id` (Number) The view ID that the templates belongs to.
 
@@ -84,6 +85,43 @@ Read-Only:
 - `required` (Boolean) Whether the survey variable is required.
 - `title` (String) The title of the survey variable.
 - `type` (String) The type of the survey variable.
+
+
+<a id="nestedatt--task_params"></a>
+### Nested Schema for `task_params`
+
+Read-Only:
+
+- `ansible` (Attributes) Ansible-specific task parameters. Use this when `app` is `ansible`. (see [below for nested schema](#nestedatt--task_params--ansible))
+- `arguments` (String) JSON-encoded array of extra command-line arguments passed to the task runner (e.g. `"[\"-vvv\"]"`).
+- `environment` (String) JSON-encoded object of environment variables exposed to the task.
+- `git_branch` (String) Override the repository branch checked out for this task.
+- `message` (String) Optional commit-style message recorded with each task run.
+- `terraform` (Attributes) Terraform / OpenTofu-specific task parameters. Use this when `app` is `terraform` or `tofu`. (see [below for nested schema](#nestedatt--task_params--terraform))
+
+<a id="nestedatt--task_params--ansible"></a>
+### Nested Schema for `task_params.ansible`
+
+Read-Only:
+
+- `debug` (Boolean) Run Ansible with `-vvvv` debug output.
+- `diff` (Boolean) Show file diffs for changes Ansible makes (`--diff`).
+- `dry_run` (Boolean) Run Ansible in check mode (`--check`).
+- `limit` (List of String) Ansible hosts to limit the run to (`--limit`).
+- `skip_tags` (List of String) Ansible tags to skip (`--skip-tags`).
+- `tags` (List of String) Ansible tags to run (`--tags`).
+
+
+<a id="nestedatt--task_params--terraform"></a>
+### Nested Schema for `task_params.terraform`
+
+Read-Only:
+
+- `auto_approve` (Boolean) Run with `-auto-approve`.
+- `destroy` (Boolean) Run a destroy (`terraform destroy` / `tofu destroy`).
+- `plan` (Boolean) Run plan-only (no apply).
+- `upgrade` (Boolean) Pass `-upgrade` to `terraform init` / `tofu init`.
+
 
 
 <a id="nestedatt--vaults"></a>

--- a/docs/resources/project_integration.md
+++ b/docs/resources/project_integration.md
@@ -113,9 +113,9 @@ Optional:
 
 Optional:
 
-- `debug` (Boolean) Run Ansible with `-vvvv` debug output.
-- `diff` (Boolean) Show file diffs for changes Ansible makes (`--diff`).
-- `dry_run` (Boolean) Run Ansible in check mode (`--check`).
+- `debug` (Boolean) Run Ansible with `-vvvv` debug output. Value defaults to `false`.
+- `diff` (Boolean) Show file diffs for changes Ansible makes (`--diff`). Value defaults to `false`.
+- `dry_run` (Boolean) Run Ansible in check mode (`--check`). Value defaults to `false`.
 - `limit` (List of String) Ansible hosts to limit the run to (`--limit`).
 - `skip_tags` (List of String) Ansible tags to skip (`--skip-tags`).
 - `tags` (List of String) Ansible tags to run (`--tags`).
@@ -126,10 +126,10 @@ Optional:
 
 Optional:
 
-- `auto_approve` (Boolean) Run with `-auto-approve`.
-- `destroy` (Boolean) Run a destroy (`terraform destroy` / `tofu destroy`).
-- `plan` (Boolean) Run plan-only (no apply).
-- `upgrade` (Boolean) Pass `-upgrade` to `terraform init` / `tofu init`.
+- `auto_approve` (Boolean) Run with `-auto-approve`. Value defaults to `false`.
+- `destroy` (Boolean) Run a destroy (`terraform destroy` / `tofu destroy`). Value defaults to `false`.
+- `plan` (Boolean) Run plan-only (no apply). Value defaults to `false`.
+- `upgrade` (Boolean) Pass `-upgrade` to `terraform init` / `tofu init`. Value defaults to `false`.
 
 ## Import
 

--- a/docs/resources/project_integration.md
+++ b/docs/resources/project_integration.md
@@ -90,10 +90,46 @@ resource "semaphoreui_project_integration" "github" {
 - `auth_method` (String) How incoming requests are authenticated. Known values: `none`, `token`, `hmac`, `github`, `gitlab`, `bitbucket`. Defaults to `none`. Value defaults to `none`.
 - `auth_secret_id` (Number) The project key ID that holds the credential used to verify incoming requests (relevant when `auth_method` is `token` or `hmac`).
 - `searchable` (Boolean) Whether to index this integration's task history for search. Value defaults to `false`.
+- `task_params` (Attributes) Default task parameters applied when this template or integration runs a task. (see [below for nested schema](#nestedatt--task_params))
 
 ### Read-Only
 
 - `id` (Number) The integration ID.
+
+<a id="nestedatt--task_params"></a>
+### Nested Schema for `task_params`
+
+Optional:
+
+- `ansible` (Attributes) Ansible-specific task parameters. Use this when `app` is `ansible`. (see [below for nested schema](#nestedatt--task_params--ansible))
+- `arguments` (String) JSON-encoded array of extra command-line arguments passed to the task runner (e.g. `"[\"-vvv\"]"`).
+- `environment` (String) JSON-encoded object of environment variables exposed to the task.
+- `git_branch` (String) Override the repository branch checked out for this task.
+- `message` (String) Optional commit-style message recorded with each task run.
+- `terraform` (Attributes) Terraform / OpenTofu-specific task parameters. Use this when `app` is `terraform` or `tofu`. (see [below for nested schema](#nestedatt--task_params--terraform))
+
+<a id="nestedatt--task_params--ansible"></a>
+### Nested Schema for `task_params.ansible`
+
+Optional:
+
+- `debug` (Boolean) Run Ansible with `-vvvv` debug output.
+- `diff` (Boolean) Show file diffs for changes Ansible makes (`--diff`).
+- `dry_run` (Boolean) Run Ansible in check mode (`--check`).
+- `limit` (List of String) Ansible hosts to limit the run to (`--limit`).
+- `skip_tags` (List of String) Ansible tags to skip (`--skip-tags`).
+- `tags` (List of String) Ansible tags to run (`--tags`).
+
+
+<a id="nestedatt--task_params--terraform"></a>
+### Nested Schema for `task_params.terraform`
+
+Optional:
+
+- `auto_approve` (Boolean) Run with `-auto-approve`.
+- `destroy` (Boolean) Run a destroy (`terraform destroy` / `tofu destroy`).
+- `plan` (Boolean) Run plan-only (no apply).
+- `upgrade` (Boolean) Pass `-upgrade` to `terraform init` / `tofu init`.
 
 ## Import
 

--- a/docs/resources/project_template.md
+++ b/docs/resources/project_template.md
@@ -145,6 +145,7 @@ resource "semaphoreui_project_template" "deploy" {
 - `playbook` (String) The playbook/script filename. Optional when `app` is `terraform` or `tofu`; required otherwise. Value defaults to ``. Must be a relative path (path/to/playbook) or empty.
 - `suppress_success_alerts` (Boolean) Suppress success alerts. Value defaults to `false`.
 - `survey_vars` (Attributes List) Survey variables. (see [below for nested schema](#nestedatt--survey_vars))
+- `task_params` (Attributes) Default task parameters applied when this template or integration runs a task. (see [below for nested schema](#nestedatt--task_params))
 - `vaults` (Attributes List) Ansible Vault Passwords. (see [below for nested schema](#nestedatt--vaults))
 - `view_id` (Number) The view ID that the templates belongs to.
 
@@ -186,6 +187,43 @@ Optional:
 - `description` (String) The description of the survey variable.
 - `enum_values` (Map of String) The enum name/values. Map must contain at least 1 elements. Ensure that if an attribute is set, also these are set: "[<.type]".
 - `required` (Boolean) Whether the survey variable is required. Value defaults to `false`.
+
+
+<a id="nestedatt--task_params"></a>
+### Nested Schema for `task_params`
+
+Optional:
+
+- `ansible` (Attributes) Ansible-specific task parameters. Use this when `app` is `ansible`. (see [below for nested schema](#nestedatt--task_params--ansible))
+- `arguments` (String) JSON-encoded array of extra command-line arguments passed to the task runner (e.g. `"[\"-vvv\"]"`).
+- `environment` (String) JSON-encoded object of environment variables exposed to the task.
+- `git_branch` (String) Override the repository branch checked out for this task.
+- `message` (String) Optional commit-style message recorded with each task run.
+- `terraform` (Attributes) Terraform / OpenTofu-specific task parameters. Use this when `app` is `terraform` or `tofu`. (see [below for nested schema](#nestedatt--task_params--terraform))
+
+<a id="nestedatt--task_params--ansible"></a>
+### Nested Schema for `task_params.ansible`
+
+Optional:
+
+- `debug` (Boolean) Run Ansible with `-vvvv` debug output.
+- `diff` (Boolean) Show file diffs for changes Ansible makes (`--diff`).
+- `dry_run` (Boolean) Run Ansible in check mode (`--check`).
+- `limit` (List of String) Ansible hosts to limit the run to (`--limit`).
+- `skip_tags` (List of String) Ansible tags to skip (`--skip-tags`).
+- `tags` (List of String) Ansible tags to run (`--tags`).
+
+
+<a id="nestedatt--task_params--terraform"></a>
+### Nested Schema for `task_params.terraform`
+
+Optional:
+
+- `auto_approve` (Boolean) Run with `-auto-approve`.
+- `destroy` (Boolean) Run a destroy (`terraform destroy` / `tofu destroy`).
+- `plan` (Boolean) Run plan-only (no apply).
+- `upgrade` (Boolean) Pass `-upgrade` to `terraform init` / `tofu init`.
+
 
 
 <a id="nestedatt--vaults"></a>

--- a/docs/resources/project_template.md
+++ b/docs/resources/project_template.md
@@ -206,9 +206,9 @@ Optional:
 
 Optional:
 
-- `debug` (Boolean) Run Ansible with `-vvvv` debug output.
-- `diff` (Boolean) Show file diffs for changes Ansible makes (`--diff`).
-- `dry_run` (Boolean) Run Ansible in check mode (`--check`).
+- `debug` (Boolean) Run Ansible with `-vvvv` debug output. Value defaults to `false`.
+- `diff` (Boolean) Show file diffs for changes Ansible makes (`--diff`). Value defaults to `false`.
+- `dry_run` (Boolean) Run Ansible in check mode (`--check`). Value defaults to `false`.
 - `limit` (List of String) Ansible hosts to limit the run to (`--limit`).
 - `skip_tags` (List of String) Ansible tags to skip (`--skip-tags`).
 - `tags` (List of String) Ansible tags to run (`--tags`).
@@ -219,10 +219,10 @@ Optional:
 
 Optional:
 
-- `auto_approve` (Boolean) Run with `-auto-approve`.
-- `destroy` (Boolean) Run a destroy (`terraform destroy` / `tofu destroy`).
-- `plan` (Boolean) Run plan-only (no apply).
-- `upgrade` (Boolean) Pass `-upgrade` to `terraform init` / `tofu init`.
+- `auto_approve` (Boolean) Run with `-auto-approve`. Value defaults to `false`.
+- `destroy` (Boolean) Run a destroy (`terraform destroy` / `tofu destroy`). Value defaults to `false`.
+- `plan` (Boolean) Run plan-only (no apply). Value defaults to `false`.
+- `upgrade` (Boolean) Pass `-upgrade` to `terraform init` / `tofu init`. Value defaults to `false`.
 
 
 

--- a/internal/provider/project_integration_data_source.go
+++ b/internal/provider/project_integration_data_source.go
@@ -44,7 +44,7 @@ func (d *projectIntegrationDataSource) Schema(ctx context.Context, _ datasource.
 	resp.Schema = ProjectIntegrationSchema().GetDataSource(ctx)
 }
 
-func (d *projectIntegrationDataSource) GetIntegrationByName(projectID int64, name string) (*ProjectIntegrationModel, error) {
+func (d *projectIntegrationDataSource) GetIntegrationByName(ctx context.Context, projectID int64, name string) (*ProjectIntegrationModel, error) {
 	response, err := d.client.Integration.GetProjectProjectIDIntegrations(&integration.GetProjectProjectIDIntegrationsParams{
 		ProjectID: projectID,
 	}, nil)
@@ -53,7 +53,7 @@ func (d *projectIntegrationDataSource) GetIntegrationByName(projectID int64, nam
 	}
 	for _, integ := range response.Payload {
 		if integ.Name == name {
-			model := convertIntegrationResponseToProjectIntegrationModel(integ)
+			model := convertIntegrationResponseToProjectIntegrationModel(ctx, integ)
 			return &model, nil
 		}
 	}
@@ -80,9 +80,9 @@ func (d *projectIntegrationDataSource) Read(ctx context.Context, req datasource.
 			)
 			return
 		}
-		model = convertIntegrationResponseToProjectIntegrationModel(response.Payload)
+		model = convertIntegrationResponseToProjectIntegrationModel(ctx, response.Payload)
 	} else if !config.Name.IsUnknown() && !config.Name.IsNull() {
-		integ, err := d.GetIntegrationByName(config.ProjectID.ValueInt64(), config.Name.ValueString())
+		integ, err := d.GetIntegrationByName(ctx, config.ProjectID.ValueInt64(), config.Name.ValueString())
 		if err != nil {
 			resp.Diagnostics.AddError(
 				"Error Reading SemaphoreUI Project Integration",

--- a/internal/provider/project_integration_resource.go
+++ b/internal/provider/project_integration_resource.go
@@ -46,7 +46,7 @@ func (r *projectIntegrationResource) Schema(ctx context.Context, _ resource.Sche
 	resp.Schema = ProjectIntegrationSchema().GetResource(ctx)
 }
 
-func convertProjectIntegrationModelToIntegrationRequest(model ProjectIntegrationModel) *models.IntegrationRequest {
+func convertProjectIntegrationModelToIntegrationRequest(ctx context.Context, model ProjectIntegrationModel) *models.IntegrationRequest {
 	req := models.IntegrationRequest{
 		ProjectID:    model.ProjectID.ValueInt64(),
 		TemplateID:   model.TemplateID.ValueInt64(),
@@ -55,6 +55,7 @@ func convertProjectIntegrationModelToIntegrationRequest(model ProjectIntegration
 		AuthSecretID: model.AuthSecretID.ValueInt64Pointer(),
 		AuthHeader:   model.AuthHeader.ValueString(),
 		Searchable:   model.Searchable.ValueBool(),
+		TaskParams:   convertTaskParamsModelToTaskPrams(ctx, model.TaskParams),
 	}
 	if !model.ID.IsNull() && !model.ID.IsUnknown() {
 		req.ID = model.ID.ValueInt64()
@@ -62,7 +63,7 @@ func convertProjectIntegrationModelToIntegrationRequest(model ProjectIntegration
 	return &req
 }
 
-func convertIntegrationResponseToProjectIntegrationModel(payload *models.Integration) ProjectIntegrationModel {
+func convertIntegrationResponseToProjectIntegrationModel(ctx context.Context, payload *models.Integration) ProjectIntegrationModel {
 	return ProjectIntegrationModel{
 		ID:           types.Int64Value(payload.ID),
 		ProjectID:    types.Int64Value(payload.ProjectID),
@@ -72,6 +73,7 @@ func convertIntegrationResponseToProjectIntegrationModel(payload *models.Integra
 		AuthSecretID: types.Int64PointerValue(payload.AuthSecretID),
 		AuthHeader:   types.StringValue(payload.AuthHeader),
 		Searchable:   types.BoolValue(payload.Searchable),
+		TaskParams:   convertTaskPramsToTaskParamsModel(ctx, payload.TaskParams),
 	}
 }
 
@@ -84,7 +86,7 @@ func (r *projectIntegrationResource) Create(ctx context.Context, req resource.Cr
 
 	response, err := r.client.Integration.PostProjectProjectIDIntegrations(&integration.PostProjectProjectIDIntegrationsParams{
 		ProjectID:   plan.ProjectID.ValueInt64(),
-		Integration: convertProjectIntegrationModelToIntegrationRequest(plan),
+		Integration: convertProjectIntegrationModelToIntegrationRequest(ctx, plan),
 	}, nil)
 	if err != nil {
 		resp.Diagnostics.AddError(
@@ -93,7 +95,7 @@ func (r *projectIntegrationResource) Create(ctx context.Context, req resource.Cr
 		)
 		return
 	}
-	model := convertIntegrationResponseToProjectIntegrationModel(response.Payload)
+	model := convertIntegrationResponseToProjectIntegrationModel(ctx, response.Payload)
 	resp.Diagnostics.Append(resp.State.Set(ctx, &model)...)
 }
 
@@ -115,7 +117,7 @@ func (r *projectIntegrationResource) Read(ctx context.Context, req resource.Read
 		)
 		return
 	}
-	model := convertIntegrationResponseToProjectIntegrationModel(response.Payload)
+	model := convertIntegrationResponseToProjectIntegrationModel(ctx, response.Payload)
 	resp.Diagnostics.Append(resp.State.Set(ctx, &model)...)
 }
 
@@ -129,7 +131,7 @@ func (r *projectIntegrationResource) Update(ctx context.Context, req resource.Up
 	_, err := r.client.Integration.PutProjectProjectIDIntegrationsIntegrationID(&integration.PutProjectProjectIDIntegrationsIntegrationIDParams{
 		ProjectID:     plan.ProjectID.ValueInt64(),
 		IntegrationID: plan.ID.ValueInt64(),
-		Integration:   convertProjectIntegrationModelToIntegrationRequest(plan),
+		Integration:   convertProjectIntegrationModelToIntegrationRequest(ctx, plan),
 	}, nil)
 	if err != nil {
 		resp.Diagnostics.AddError(
@@ -150,7 +152,7 @@ func (r *projectIntegrationResource) Update(ctx context.Context, req resource.Up
 		)
 		return
 	}
-	model := convertIntegrationResponseToProjectIntegrationModel(response.Payload)
+	model := convertIntegrationResponseToProjectIntegrationModel(ctx, response.Payload)
 	resp.Diagnostics.Append(resp.State.Set(ctx, &model)...)
 }
 
@@ -195,6 +197,6 @@ func (r *projectIntegrationResource) ImportState(ctx context.Context, req resour
 		)
 		return
 	}
-	model := convertIntegrationResponseToProjectIntegrationModel(response.Payload)
+	model := convertIntegrationResponseToProjectIntegrationModel(ctx, response.Payload)
 	resp.Diagnostics.Append(resp.State.Set(ctx, &model)...)
 }

--- a/internal/provider/project_integration_resource_test.go
+++ b/internal/provider/project_integration_resource_test.go
@@ -175,3 +175,47 @@ func TestAcc_ProjectIntegrationResource_basic(t *testing.T) {
 		},
 	})
 }
+
+func TestAcc_ProjectIntegrationResource_taskParams(t *testing.T) {
+	nameSuffix := acctest.RandString(8)
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			// Create with task_params.ansible set.
+			{
+				Config: testAccProjectIntegrationConfig(nameSuffix, `
+  task_params = {
+    environment = "{}"
+    ansible = {
+      tags      = ["deploy"]
+      skip_tags = ["slow"]
+    }
+  }
+`),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccProjectIntegrationExists("semaphoreui_project_integration.test"),
+					resource.TestCheckResourceAttr("semaphoreui_project_integration.test", "task_params.environment", "{}"),
+					resource.TestCheckResourceAttr("semaphoreui_project_integration.test", "task_params.ansible.tags.#", "1"),
+					resource.TestCheckResourceAttr("semaphoreui_project_integration.test", "task_params.ansible.tags.0", "deploy"),
+					resource.TestCheckResourceAttr("semaphoreui_project_integration.test", "task_params.ansible.skip_tags.0", "slow"),
+				),
+			},
+			// Clear task_params.
+			{
+				Config: testAccProjectIntegrationConfig(nameSuffix, ""),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccProjectIntegrationExists("semaphoreui_project_integration.test"),
+					resource.TestCheckNoResourceAttr("semaphoreui_project_integration.test", "task_params"),
+				),
+			},
+			// Delete
+			{
+				Config: testAccProjectIntegrationDependencyConfig(nameSuffix),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccResourceNotExists("semaphoreui_project_integration.test"),
+				),
+			},
+		},
+	})
+}

--- a/internal/provider/project_integration_schema.go
+++ b/internal/provider/project_integration_schema.go
@@ -16,14 +16,15 @@ import (
 )
 
 type ProjectIntegrationModel struct {
-	ID           types.Int64  `tfsdk:"id"`
-	ProjectID    types.Int64  `tfsdk:"project_id"`
-	TemplateID   types.Int64  `tfsdk:"template_id"`
-	Name         types.String `tfsdk:"name"`
-	AuthMethod   types.String `tfsdk:"auth_method"`
-	AuthSecretID types.Int64  `tfsdk:"auth_secret_id"`
-	AuthHeader   types.String `tfsdk:"auth_header"`
-	Searchable   types.Bool   `tfsdk:"searchable"`
+	ID           types.Int64      `tfsdk:"id"`
+	ProjectID    types.Int64      `tfsdk:"project_id"`
+	TemplateID   types.Int64      `tfsdk:"template_id"`
+	Name         types.String     `tfsdk:"name"`
+	AuthMethod   types.String     `tfsdk:"auth_method"`
+	AuthSecretID types.Int64      `tfsdk:"auth_secret_id"`
+	AuthHeader   types.String     `tfsdk:"auth_header"`
+	Searchable   types.Bool       `tfsdk:"searchable"`
+	TaskParams   *TaskParamsModel `tfsdk:"task_params"`
 }
 
 func ProjectIntegrationSchema() superschema.Schema {
@@ -145,6 +146,7 @@ func ProjectIntegrationSchema() superschema.Schema {
 					Computed: true,
 				},
 			},
+			"task_params": TaskParamsAttribute(),
 		},
 	}
 }

--- a/internal/provider/project_template_resource.go
+++ b/internal/provider/project_template_resource.go
@@ -196,6 +196,8 @@ func convertProjectTemplateModelToTemplateRequest(ctx context.Context, template 
 		}
 	}
 
+	model.TaskParams = convertTaskParamsModelToTaskPrams(ctx, template.TaskParams)
+
 	return &model
 }
 
@@ -331,6 +333,8 @@ func convertTemplateResponseToProjectTemplateModel(ctx context.Context, request 
 		vaultsModel, _ := types.ListValueFrom(ctx, ProjectTemplateVaultType, &vaults)
 		model.Vaults = vaultsModel
 	}
+
+	model.TaskParams = convertTaskPramsToTaskParamsModel(ctx, request.TaskParams)
 
 	return model
 }

--- a/internal/provider/project_template_resource_test.go
+++ b/internal/provider/project_template_resource_test.go
@@ -676,3 +676,110 @@ vaults = [{
 		},
 	})
 }
+
+func TestAcc_ProjectTemplateResource_taskParams(t *testing.T) {
+	nameSuffix := acctest.RandString(8)
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			// Create with Ansible task_params — tags, skip_tags, diff.
+			{
+				Config: testAccProjectTemplateConfig(nameSuffix, `
+  task_params = {
+    arguments = "[\"-v\"]"
+    ansible = {
+      tags      = ["deploy", "db"]
+      skip_tags = ["slow"]
+      diff      = true
+    }
+  }
+`),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccProjectTemplateExists("semaphoreui_project_template.test", ""),
+					resource.TestCheckResourceAttr("semaphoreui_project_template.test", "task_params.arguments", "[\"-v\"]"),
+					resource.TestCheckResourceAttr("semaphoreui_project_template.test", "task_params.ansible.tags.#", "2"),
+					resource.TestCheckResourceAttr("semaphoreui_project_template.test", "task_params.ansible.tags.0", "deploy"),
+					resource.TestCheckResourceAttr("semaphoreui_project_template.test", "task_params.ansible.tags.1", "db"),
+					resource.TestCheckResourceAttr("semaphoreui_project_template.test", "task_params.ansible.skip_tags.#", "1"),
+					resource.TestCheckResourceAttr("semaphoreui_project_template.test", "task_params.ansible.skip_tags.0", "slow"),
+					resource.TestCheckResourceAttr("semaphoreui_project_template.test", "task_params.ansible.diff", "true"),
+					resource.TestCheckNoResourceAttr("semaphoreui_project_template.test", "task_params.terraform"),
+				),
+			},
+			// ImportState
+			{
+				ResourceName:      "semaphoreui_project_template.test",
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateIdFunc: testAccProjectTemplateImportID("semaphoreui_project_template.test"),
+			},
+			// Update tags (rotate).
+			{
+				Config: testAccProjectTemplateConfig(nameSuffix, `
+  task_params = {
+    ansible = {
+      tags = ["only-this"]
+    }
+  }
+`),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("semaphoreui_project_template.test", "task_params.ansible.tags.#", "1"),
+					resource.TestCheckResourceAttr("semaphoreui_project_template.test", "task_params.ansible.tags.0", "only-this"),
+					resource.TestCheckNoResourceAttr("semaphoreui_project_template.test", "task_params.ansible.skip_tags"),
+					resource.TestCheckResourceAttr("semaphoreui_project_template.test", "task_params.ansible.diff", "false"),
+				),
+			},
+			// Clear task_params entirely.
+			{
+				Config: testAccProjectTemplateConfig(nameSuffix, ""),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckNoResourceAttr("semaphoreui_project_template.test", "task_params"),
+				),
+			},
+			// Delete
+			{
+				Config: testAccProjectTemplateDependencyConfig(nameSuffix),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccResourceNotExists("semaphoreui_project_template.test"),
+				),
+			},
+		},
+	})
+}
+
+func TestAcc_ProjectTemplateResource_taskParamsTerraform(t *testing.T) {
+	nameSuffix := acctest.RandString(8)
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			// Create a Terraform app template with auto_approve.
+			{
+				Config: testAccProjectTemplateConfig(nameSuffix, `
+  app = "terraform"
+  task_params = {
+    terraform = {
+      auto_approve = true
+      upgrade      = true
+    }
+  }
+`),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccProjectTemplateExists("semaphoreui_project_template.test", ""),
+					resource.TestCheckResourceAttr("semaphoreui_project_template.test", "app", "terraform"),
+					resource.TestCheckResourceAttr("semaphoreui_project_template.test", "task_params.terraform.auto_approve", "true"),
+					resource.TestCheckResourceAttr("semaphoreui_project_template.test", "task_params.terraform.upgrade", "true"),
+					resource.TestCheckNoResourceAttr("semaphoreui_project_template.test", "task_params.ansible"),
+				),
+			},
+			// Delete
+			{
+				Config: testAccProjectTemplateDependencyConfig(nameSuffix),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccResourceNotExists("semaphoreui_project_template.test"),
+				),
+			},
+		},
+	})
+}

--- a/internal/provider/project_template_schema.go
+++ b/internal/provider/project_template_schema.go
@@ -41,6 +41,8 @@ type (
 
 		Build  *ProjectTemplateTypeBuildModel  `tfsdk:"build"`
 		Deploy *ProjectTemplateTypeDeployModel `tfsdk:"deploy"`
+
+		TaskParams *TaskParamsModel `tfsdk:"task_params"`
 	}
 
 	ProjectTemplateTypeBuildModel struct {
@@ -562,6 +564,7 @@ func ProjectTemplateSchema() superschema.Schema {
 					},
 				},
 			},
+			"task_params": TaskParamsAttribute(),
 		},
 	}
 }

--- a/internal/provider/task_params_schema.go
+++ b/internal/provider/task_params_schema.go
@@ -1,0 +1,361 @@
+package provider
+
+import (
+	"context"
+
+	schemaD "github.com/hashicorp/terraform-plugin-framework/datasource/schema"
+	schemaR "github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/booldefault"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	superschema "github.com/orange-cloudavenue/terraform-plugin-framework-superschema"
+
+	"terraform-provider-semaphoreui/semaphoreui/models"
+)
+
+// TaskParamsModel mirrors the SemaphoreUI TaskPrams JSON object. Used by
+// both project templates and project integrations.
+type TaskParamsModel struct {
+	Arguments   types.String              `tfsdk:"arguments"`
+	Environment types.String              `tfsdk:"environment"`
+	GitBranch   types.String              `tfsdk:"git_branch"`
+	Message     types.String              `tfsdk:"message"`
+	Ansible     *AnsibleTaskParamsModel   `tfsdk:"ansible"`
+	Terraform   *TerraformTaskParamsModel `tfsdk:"terraform"`
+}
+
+type AnsibleTaskParamsModel struct {
+	Tags     types.List `tfsdk:"tags"`
+	SkipTags types.List `tfsdk:"skip_tags"`
+	Limit    types.List `tfsdk:"limit"`
+	Debug    types.Bool `tfsdk:"debug"`
+	Diff     types.Bool `tfsdk:"diff"`
+	DryRun   types.Bool `tfsdk:"dry_run"`
+}
+
+type TerraformTaskParamsModel struct {
+	AutoApprove types.Bool `tfsdk:"auto_approve"`
+	Destroy     types.Bool `tfsdk:"destroy"`
+	Plan        types.Bool `tfsdk:"plan"`
+	Upgrade     types.Bool `tfsdk:"upgrade"`
+}
+
+// TaskParamsAttribute returns the shared `task_params` attribute used by
+// project_template and project_integration resources / data sources.
+func TaskParamsAttribute() superschema.Attribute {
+	return superschema.SingleNestedAttribute{
+		Common: &schemaR.SingleNestedAttribute{
+			MarkdownDescription: "Default task parameters applied when this template or integration runs a task.",
+		},
+		Resource: &schemaR.SingleNestedAttribute{
+			Optional: true,
+		},
+		DataSource: &schemaD.SingleNestedAttribute{
+			Computed: true,
+		},
+		Attributes: map[string]superschema.Attribute{
+			"arguments": superschema.StringAttribute{
+				Common: &schemaR.StringAttribute{
+					MarkdownDescription: "JSON-encoded array of extra command-line arguments passed to the task runner (e.g. `\"[\\\"-vvv\\\"]\"`).",
+				},
+				Resource: &schemaR.StringAttribute{
+					Optional: true,
+				},
+				DataSource: &schemaD.StringAttribute{
+					Computed: true,
+				},
+			},
+			"environment": superschema.StringAttribute{
+				Common: &schemaR.StringAttribute{
+					MarkdownDescription: "JSON-encoded object of environment variables exposed to the task.",
+				},
+				Resource: &schemaR.StringAttribute{
+					Optional: true,
+				},
+				DataSource: &schemaD.StringAttribute{
+					Computed: true,
+				},
+			},
+			"git_branch": superschema.StringAttribute{
+				Common: &schemaR.StringAttribute{
+					MarkdownDescription: "Override the repository branch checked out for this task.",
+				},
+				Resource: &schemaR.StringAttribute{
+					Optional: true,
+				},
+				DataSource: &schemaD.StringAttribute{
+					Computed: true,
+				},
+			},
+			"message": superschema.StringAttribute{
+				Common: &schemaR.StringAttribute{
+					MarkdownDescription: "Optional commit-style message recorded with each task run.",
+				},
+				Resource: &schemaR.StringAttribute{
+					Optional: true,
+				},
+				DataSource: &schemaD.StringAttribute{
+					Computed: true,
+				},
+			},
+			"ansible": superschema.SingleNestedAttribute{
+				Common: &schemaR.SingleNestedAttribute{
+					MarkdownDescription: "Ansible-specific task parameters. Use this when `app` is `ansible`.",
+				},
+				Resource: &schemaR.SingleNestedAttribute{
+					Optional: true,
+				},
+				DataSource: &schemaD.SingleNestedAttribute{
+					Computed: true,
+				},
+				Attributes: map[string]superschema.Attribute{
+					"tags": superschema.ListAttribute{
+						Common: &schemaR.ListAttribute{
+							MarkdownDescription: "Ansible tags to run (`--tags`).",
+							ElementType:         types.StringType,
+						},
+						Resource: &schemaR.ListAttribute{
+							Optional: true,
+						},
+						DataSource: &schemaD.ListAttribute{
+							Computed: true,
+						},
+					},
+					"skip_tags": superschema.ListAttribute{
+						Common: &schemaR.ListAttribute{
+							MarkdownDescription: "Ansible tags to skip (`--skip-tags`).",
+							ElementType:         types.StringType,
+						},
+						Resource: &schemaR.ListAttribute{
+							Optional: true,
+						},
+						DataSource: &schemaD.ListAttribute{
+							Computed: true,
+						},
+					},
+					"limit": superschema.ListAttribute{
+						Common: &schemaR.ListAttribute{
+							MarkdownDescription: "Ansible hosts to limit the run to (`--limit`).",
+							ElementType:         types.StringType,
+						},
+						Resource: &schemaR.ListAttribute{
+							Optional: true,
+						},
+						DataSource: &schemaD.ListAttribute{
+							Computed: true,
+						},
+					},
+					"debug": superschema.BoolAttribute{
+						Common: &schemaR.BoolAttribute{
+							MarkdownDescription: "Run Ansible with `-vvvv` debug output.",
+						},
+						Resource: &schemaR.BoolAttribute{
+							Optional: true,
+							Computed: true,
+							Default:  booldefault.StaticBool(false),
+						},
+						DataSource: &schemaD.BoolAttribute{
+							Computed: true,
+						},
+					},
+					"diff": superschema.BoolAttribute{
+						Common: &schemaR.BoolAttribute{
+							MarkdownDescription: "Show file diffs for changes Ansible makes (`--diff`).",
+						},
+						Resource: &schemaR.BoolAttribute{
+							Optional: true,
+							Computed: true,
+							Default:  booldefault.StaticBool(false),
+						},
+						DataSource: &schemaD.BoolAttribute{
+							Computed: true,
+						},
+					},
+					"dry_run": superschema.BoolAttribute{
+						Common: &schemaR.BoolAttribute{
+							MarkdownDescription: "Run Ansible in check mode (`--check`).",
+						},
+						Resource: &schemaR.BoolAttribute{
+							Optional: true,
+							Computed: true,
+							Default:  booldefault.StaticBool(false),
+						},
+						DataSource: &schemaD.BoolAttribute{
+							Computed: true,
+						},
+					},
+				},
+			},
+			"terraform": superschema.SingleNestedAttribute{
+				Common: &schemaR.SingleNestedAttribute{
+					MarkdownDescription: "Terraform / OpenTofu-specific task parameters. Use this when `app` is `terraform` or `tofu`.",
+				},
+				Resource: &schemaR.SingleNestedAttribute{
+					Optional: true,
+				},
+				DataSource: &schemaD.SingleNestedAttribute{
+					Computed: true,
+				},
+				Attributes: map[string]superschema.Attribute{
+					"auto_approve": superschema.BoolAttribute{
+						Common: &schemaR.BoolAttribute{
+							MarkdownDescription: "Run with `-auto-approve`.",
+						},
+						Resource: &schemaR.BoolAttribute{
+							Optional: true,
+							Computed: true,
+							Default:  booldefault.StaticBool(false),
+						},
+						DataSource: &schemaD.BoolAttribute{
+							Computed: true,
+						},
+					},
+					"destroy": superschema.BoolAttribute{
+						Common: &schemaR.BoolAttribute{
+							MarkdownDescription: "Run a destroy (`terraform destroy` / `tofu destroy`).",
+						},
+						Resource: &schemaR.BoolAttribute{
+							Optional: true,
+							Computed: true,
+							Default:  booldefault.StaticBool(false),
+						},
+						DataSource: &schemaD.BoolAttribute{
+							Computed: true,
+						},
+					},
+					"plan": superschema.BoolAttribute{
+						Common: &schemaR.BoolAttribute{
+							MarkdownDescription: "Run plan-only (no apply).",
+						},
+						Resource: &schemaR.BoolAttribute{
+							Optional: true,
+							Computed: true,
+							Default:  booldefault.StaticBool(false),
+						},
+						DataSource: &schemaD.BoolAttribute{
+							Computed: true,
+						},
+					},
+					"upgrade": superschema.BoolAttribute{
+						Common: &schemaR.BoolAttribute{
+							MarkdownDescription: "Pass `-upgrade` to `terraform init` / `tofu init`.",
+						},
+						Resource: &schemaR.BoolAttribute{
+							Optional: true,
+							Computed: true,
+							Default:  booldefault.StaticBool(false),
+						},
+						DataSource: &schemaD.BoolAttribute{
+							Computed: true,
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+// convertTaskParamsModelToTaskPrams converts a Terraform model into the
+// generated client's TaskPrams. Returns nil if the model is unset, so callers
+// can omit task_params from requests cleanly.
+func convertTaskParamsModelToTaskPrams(ctx context.Context, model *TaskParamsModel) *models.TaskPrams {
+	if model == nil {
+		return nil
+	}
+	out := &models.TaskPrams{
+		Arguments:   model.Arguments.ValueString(),
+		Environment: model.Environment.ValueString(),
+		GitBranch:   model.GitBranch.ValueString(),
+		Message:     model.Message.ValueString(),
+	}
+	if model.Ansible != nil {
+		out.Params.AnsibleTaskParams = models.AnsibleTaskParams{
+			Tags:     stringListToSlice(ctx, model.Ansible.Tags),
+			SkipTags: stringListToSlice(ctx, model.Ansible.SkipTags),
+			Limit:    stringListToSlice(ctx, model.Ansible.Limit),
+			Debug:    model.Ansible.Debug.ValueBool(),
+			Diff:     model.Ansible.Diff.ValueBool(),
+			DryRun:   model.Ansible.DryRun.ValueBool(),
+		}
+	}
+	if model.Terraform != nil {
+		out.Params.TerraformTaskParams = models.TerraformTaskParams{
+			AutoApprove: model.Terraform.AutoApprove.ValueBool(),
+			Destroy:     model.Terraform.Destroy.ValueBool(),
+			Plan:        model.Terraform.Plan.ValueBool(),
+			Upgrade:     model.Terraform.Upgrade.ValueBool(),
+		}
+	}
+	return out
+}
+
+// convertTaskPramsToTaskParamsModel converts the generated client's TaskPrams
+// back into the Terraform model shape. Returns nil if the input is nil.
+//
+// Note on round-trip: the API omits fields that weren't sent (JSON
+// `omitempty`-style behavior), so a TaskPrams returned by GET only reflects
+// what was previously written. Empty slices show up as Terraform-null lists,
+// and false booleans aren't always echoed. Callers should treat the returned
+// model as authoritative for what's stored server-side.
+func convertTaskPramsToTaskParamsModel(ctx context.Context, in *models.TaskPrams) *TaskParamsModel {
+	if in == nil {
+		return nil
+	}
+	out := &TaskParamsModel{
+		Arguments:   stringOrNull(in.Arguments),
+		Environment: stringOrNull(in.Environment),
+		GitBranch:   stringOrNull(in.GitBranch),
+		Message:     stringOrNull(in.Message),
+	}
+	if !ansibleTaskParamsEmpty(in.Params.AnsibleTaskParams) {
+		out.Ansible = &AnsibleTaskParamsModel{
+			Tags:     sliceToStringList(ctx, in.Params.Tags),
+			SkipTags: sliceToStringList(ctx, in.Params.SkipTags),
+			Limit:    sliceToStringList(ctx, in.Params.Limit),
+			Debug:    types.BoolValue(in.Params.Debug),
+			Diff:     types.BoolValue(in.Params.Diff),
+			DryRun:   types.BoolValue(in.Params.DryRun),
+		}
+	}
+	if !terraformTaskParamsEmpty(in.Params.TerraformTaskParams) {
+		out.Terraform = &TerraformTaskParamsModel{
+			AutoApprove: types.BoolValue(in.Params.AutoApprove),
+			Destroy:     types.BoolValue(in.Params.Destroy),
+			Plan:        types.BoolValue(in.Params.Plan),
+			Upgrade:     types.BoolValue(in.Params.Upgrade),
+		}
+	}
+	return out
+}
+
+func ansibleTaskParamsEmpty(p models.AnsibleTaskParams) bool {
+	return len(p.Tags) == 0 && len(p.SkipTags) == 0 && len(p.Limit) == 0 &&
+		!p.Debug && !p.Diff && !p.DryRun
+}
+
+func terraformTaskParamsEmpty(p models.TerraformTaskParams) bool {
+	return !p.AutoApprove && !p.Destroy && !p.Plan && !p.Upgrade
+}
+
+func stringOrNull(s string) types.String {
+	if s == "" {
+		return types.StringNull()
+	}
+	return types.StringValue(s)
+}
+
+func stringListToSlice(ctx context.Context, list types.List) []string {
+	if list.IsNull() || list.IsUnknown() {
+		return nil
+	}
+	var out []string
+	list.ElementsAs(ctx, &out, false)
+	return out
+}
+
+func sliceToStringList(ctx context.Context, s []string) types.List {
+	if len(s) == 0 {
+		return types.ListNull(types.StringType)
+	}
+	out, _ := types.ListValueFrom(ctx, types.StringType, s)
+	return out
+}

--- a/semaphoreui/models/integration_request.go
+++ b/semaphoreui/models/integration_request.go
@@ -33,14 +33,14 @@ type IntegrationRequest struct {
 	// Example: deploy
 	Name string `json:"name,omitempty"`
 
-	// params
-	Params *TaskPrams `json:"params,omitempty"`
-
 	// project id
 	ProjectID int64 `json:"project_id,omitempty"`
 
 	// searchable
 	Searchable bool `json:"searchable,omitempty"`
+
+	// task params
+	TaskParams *TaskPrams `json:"task_params,omitempty"`
 
 	// template id
 	TemplateID int64 `json:"template_id,omitempty"`
@@ -50,7 +50,7 @@ type IntegrationRequest struct {
 func (m *IntegrationRequest) Validate(formats strfmt.Registry) error {
 	var res []error
 
-	if err := m.validateParams(formats); err != nil {
+	if err := m.validateTaskParams(formats); err != nil {
 		res = append(res, err)
 	}
 
@@ -60,20 +60,20 @@ func (m *IntegrationRequest) Validate(formats strfmt.Registry) error {
 	return nil
 }
 
-func (m *IntegrationRequest) validateParams(formats strfmt.Registry) error {
-	if swag.IsZero(m.Params) { // not required
+func (m *IntegrationRequest) validateTaskParams(formats strfmt.Registry) error {
+	if swag.IsZero(m.TaskParams) { // not required
 		return nil
 	}
 
-	if m.Params != nil {
-		if err := m.Params.Validate(formats); err != nil {
+	if m.TaskParams != nil {
+		if err := m.TaskParams.Validate(formats); err != nil {
 			ve := new(errors.Validation)
 			if stderrors.As(err, &ve) {
-				return ve.ValidateName("params")
+				return ve.ValidateName("task_params")
 			}
 			ce := new(errors.CompositeError)
 			if stderrors.As(err, &ce) {
-				return ce.ValidateName("params")
+				return ce.ValidateName("task_params")
 			}
 
 			return err
@@ -87,7 +87,7 @@ func (m *IntegrationRequest) validateParams(formats strfmt.Registry) error {
 func (m *IntegrationRequest) ContextValidate(ctx context.Context, formats strfmt.Registry) error {
 	var res []error
 
-	if err := m.contextValidateParams(ctx, formats); err != nil {
+	if err := m.contextValidateTaskParams(ctx, formats); err != nil {
 		res = append(res, err)
 	}
 
@@ -97,22 +97,22 @@ func (m *IntegrationRequest) ContextValidate(ctx context.Context, formats strfmt
 	return nil
 }
 
-func (m *IntegrationRequest) contextValidateParams(ctx context.Context, formats strfmt.Registry) error {
+func (m *IntegrationRequest) contextValidateTaskParams(ctx context.Context, formats strfmt.Registry) error {
 
-	if m.Params != nil {
+	if m.TaskParams != nil {
 
-		if swag.IsZero(m.Params) { // not required
+		if swag.IsZero(m.TaskParams) { // not required
 			return nil
 		}
 
-		if err := m.Params.ContextValidate(ctx, formats); err != nil {
+		if err := m.TaskParams.ContextValidate(ctx, formats); err != nil {
 			ve := new(errors.Validation)
 			if stderrors.As(err, &ve) {
-				return ve.ValidateName("params")
+				return ve.ValidateName("task_params")
 			}
 			ce := new(errors.CompositeError)
 			if stderrors.As(err, &ce) {
-				return ce.ValidateName("params")
+				return ce.ValidateName("task_params")
 			}
 
 			return err

--- a/semaphoreui/models/template.go
+++ b/semaphoreui/models/template.go
@@ -83,6 +83,9 @@ type Template struct {
 	// survey vars
 	SurveyVars []*TemplateSurveyVar `json:"survey_vars"`
 
+	// task params
+	TaskParams *TaskPrams `json:"task_params,omitempty"`
+
 	// type
 	// Enum: ["","build","deploy"]
 	Type string `json:"type,omitempty"`
@@ -116,6 +119,10 @@ func (m *Template) Validate(formats strfmt.Registry) error {
 	}
 
 	if err := m.validateSurveyVars(formats); err != nil {
+		res = append(res, err)
+	}
+
+	if err := m.validateTaskParams(formats); err != nil {
 		res = append(res, err)
 	}
 
@@ -210,6 +217,29 @@ func (m *Template) validateSurveyVars(formats strfmt.Registry) error {
 			}
 		}
 
+	}
+
+	return nil
+}
+
+func (m *Template) validateTaskParams(formats strfmt.Registry) error {
+	if swag.IsZero(m.TaskParams) { // not required
+		return nil
+	}
+
+	if m.TaskParams != nil {
+		if err := m.TaskParams.Validate(formats); err != nil {
+			ve := new(errors.Validation)
+			if stderrors.As(err, &ve) {
+				return ve.ValidateName("task_params")
+			}
+			ce := new(errors.CompositeError)
+			if stderrors.As(err, &ce) {
+				return ce.ValidateName("task_params")
+			}
+
+			return err
+		}
 	}
 
 	return nil
@@ -310,6 +340,10 @@ func (m *Template) ContextValidate(ctx context.Context, formats strfmt.Registry)
 		res = append(res, err)
 	}
 
+	if err := m.contextValidateTaskParams(ctx, formats); err != nil {
+		res = append(res, err)
+	}
+
 	if err := m.contextValidateVaults(ctx, formats); err != nil {
 		res = append(res, err)
 	}
@@ -344,6 +378,31 @@ func (m *Template) contextValidateSurveyVars(ctx context.Context, formats strfmt
 			}
 		}
 
+	}
+
+	return nil
+}
+
+func (m *Template) contextValidateTaskParams(ctx context.Context, formats strfmt.Registry) error {
+
+	if m.TaskParams != nil {
+
+		if swag.IsZero(m.TaskParams) { // not required
+			return nil
+		}
+
+		if err := m.TaskParams.ContextValidate(ctx, formats); err != nil {
+			ve := new(errors.Validation)
+			if stderrors.As(err, &ve) {
+				return ve.ValidateName("task_params")
+			}
+			ce := new(errors.CompositeError)
+			if stderrors.As(err, &ce) {
+				return ce.ValidateName("task_params")
+			}
+
+			return err
+		}
 	}
 
 	return nil

--- a/semaphoreui/models/template_request.go
+++ b/semaphoreui/models/template_request.go
@@ -88,6 +88,9 @@ type TemplateRequest struct {
 	// survey vars
 	SurveyVars []*TemplateSurveyVar `json:"survey_vars"`
 
+	// task params
+	TaskParams *TaskPrams `json:"task_params,omitempty"`
+
 	// type
 	// Enum: ["","build","deploy"]
 	Type string `json:"type,omitempty"`
@@ -121,6 +124,10 @@ func (m *TemplateRequest) Validate(formats strfmt.Registry) error {
 	}
 
 	if err := m.validateSurveyVars(formats); err != nil {
+		res = append(res, err)
+	}
+
+	if err := m.validateTaskParams(formats); err != nil {
 		res = append(res, err)
 	}
 
@@ -215,6 +222,29 @@ func (m *TemplateRequest) validateSurveyVars(formats strfmt.Registry) error {
 			}
 		}
 
+	}
+
+	return nil
+}
+
+func (m *TemplateRequest) validateTaskParams(formats strfmt.Registry) error {
+	if swag.IsZero(m.TaskParams) { // not required
+		return nil
+	}
+
+	if m.TaskParams != nil {
+		if err := m.TaskParams.Validate(formats); err != nil {
+			ve := new(errors.Validation)
+			if stderrors.As(err, &ve) {
+				return ve.ValidateName("task_params")
+			}
+			ce := new(errors.CompositeError)
+			if stderrors.As(err, &ce) {
+				return ce.ValidateName("task_params")
+			}
+
+			return err
+		}
 	}
 
 	return nil
@@ -315,6 +345,10 @@ func (m *TemplateRequest) ContextValidate(ctx context.Context, formats strfmt.Re
 		res = append(res, err)
 	}
 
+	if err := m.contextValidateTaskParams(ctx, formats); err != nil {
+		res = append(res, err)
+	}
+
 	if err := m.contextValidateVaults(ctx, formats); err != nil {
 		res = append(res, err)
 	}
@@ -349,6 +383,31 @@ func (m *TemplateRequest) contextValidateSurveyVars(ctx context.Context, formats
 			}
 		}
 
+	}
+
+	return nil
+}
+
+func (m *TemplateRequest) contextValidateTaskParams(ctx context.Context, formats strfmt.Registry) error {
+
+	if m.TaskParams != nil {
+
+		if swag.IsZero(m.TaskParams) { // not required
+			return nil
+		}
+
+		if err := m.TaskParams.ContextValidate(ctx, formats); err != nil {
+			ve := new(errors.Validation)
+			if stderrors.As(err, &ve) {
+				return ve.ValidateName("task_params")
+			}
+			ce := new(errors.CompositeError)
+			if stderrors.As(err, &ce) {
+				return ce.ValidateName("task_params")
+			}
+
+			return err
+		}
 	}
 
 	return nil


### PR DESCRIPTION
## Summary

Exposes the SemaphoreUI `TaskPrams` structure as a nested `task_params` attribute on `semaphoreui_project_template` and `semaphoreui_project_integration`.

Closes **issue #53** (Ansible `tag` / `skip_tag` on templates) and rounds out the integration resource added in PR #80 (the resource shipped without `task_params` so it could land as a smaller PR — this PR completes it).

This is **PR B** in the planned series:

```
✓ PR A  semaphoreui_project_integration   (merged in #80)
> PR B  task_params (templates + integration)   ← this PR
  PR C  semaphoreui_integration_alias
  PR D  write-only ssh.private_key   (closes #58)
```

## Schema

`task_params` is a single nested attribute on both resources:

```hcl
resource "semaphoreui_project_template" "deploy" {
  app           = "ansible"
  project_id    = semaphoreui_project.p.id
  inventory_id  = semaphoreui_project_inventory.i.id
  repository_id = semaphoreui_project_repository.r.id
  name          = "Deploy"
  playbook      = "deploy.yml"

  task_params = {
    arguments   = "[\"-v\"]"   # JSON-encoded extra command-line args
    environment = "{}"          # JSON-encoded env vars
    git_branch  = "main"        # override the template's branch
    message     = ""

    ansible = {                 # populated when app is ansible
      tags      = ["deploy", "db"]
      skip_tags = ["slow"]
      limit     = ["host1"]
      debug     = false
      diff      = true
      dry_run   = false
    }

    terraform = {               # populated when app is terraform or tofu
      auto_approve = true
      destroy      = false
      plan         = false
      upgrade      = true
    }
  }
}
```

`ansible` and `terraform` sub-blocks aren't mutually exclusive — the API doesn't enforce it either. Set whichever matches your `app`.

Bool fields under `ansible` and `terraform` are `Optional+Computed` with a `false` default. This is necessary because:
- The Semaphore API returns absent fields rather than `false` explicitly
- Go's zero value for `bool` is `false`
- Without the default, an unset bool would plan as null but read back as false → "inconsistent values for sensitive attribute" post-apply

## `api-docs.yml` patches discovered by probing v2.18.2

1. **Added `task_params: $ref: TaskPrams` to `Template` and `TemplateRequest`.** Upstream omits these, but the API accepts and persists `task_params` on template create/update (confirmed via direct probe).
2. **Renamed `IntegrationRequest.params` → `task_params`** to match the actual API contract. The previous spec said `params:` but sending that field was silently dropped — only `task_params:` is read by the server. Same field name as `Integration` now, which matches what the response uses.

## Shared schema

Added `internal/provider/task_params_schema.go` with `TaskParamsModel`, `TaskParamsAttribute()`, and the `to/from-models` converters. Both `project_template` and `project_integration` resources import the attribute via a single `TaskParamsAttribute()` call so the schema stays in sync between consumers — if a new field is added (e.g. for a new app like `bash`), it lands in one place.

## Test results (local)

| SEMAPHORE_VERSION | Result | Coverage |
|---|---|---|
| v2.16.51 | 57 pass / 0 skip / 0 fail | 75.5% |
| v2.17.39 | 57 pass / 0 skip / 0 fail | 75.5% |
| v2.18.2  | 57 pass / 0 skip / 0 fail | 75.5% |

New tests:
- `TestAcc_ProjectTemplateResource_taskParams` — Ansible flow: create with tags/skip_tags/diff, rotate tags, clear `task_params`, delete
- `TestAcc_ProjectTemplateResource_taskParamsTerraform` — Terraform flow: `app=terraform` with `auto_approve` + `upgrade`
- `TestAcc_ProjectIntegrationResource_taskParams` — same coverage on integration

## Test plan

- [x] Local `task testacc` against each matrix version
- [x] `task lint` clean
- [x] `task generate` clean
- [x] Round-trip (create → import → re-apply with no diff) works for tags, skip_tags, bool fields
- [ ] CI matrix passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)