### PR TITLE
fix: don't fail project_template playbook validator on unknown (for_each) values

### DIFF
--- a/internal/provider/project_template_resource.go
+++ b/internal/provider/project_template_resource.go
@@ -73,11 +73,19 @@ func (v playbookRequiredValidator) ValidateResource(ctx context.Context, req res
 	if resp.Diagnostics.HasError() {
 		return
 	}
-	if !data.Playbook.IsNull() && !data.Playbook.IsUnknown() && data.Playbook.ValueString() != "" {
+	// Unknown values are only resolved at apply time (e.g. playbook/app driven
+	// by for_each keys/values or other computed inputs). Config validation runs
+	// once with those unknown, so treating unknown as "unset" produces a false
+	// "Missing playbook" error and blocks plan/apply, not just validate. Defer
+	// instead: the concrete value is validated when it is known. See issue #86.
+	if data.Playbook.IsUnknown() || data.App.IsUnknown() {
+		return
+	}
+	if !data.Playbook.IsNull() && data.Playbook.ValueString() != "" {
 		return
 	}
 	app := data.App.ValueString()
-	if data.App.IsNull() || data.App.IsUnknown() {
+	if data.App.IsNull() {
 		app = "ansible" // matches the schema default
 	}
 	if app == "terraform" || app == "tofu" {


### PR DESCRIPTION
Fixes #86.

## Problem
`playbookRequiredValidator` (a `ConfigValidator` on `semaphoreui_project_template`) errors with **"Missing playbook — playbook is required when app is not \`terraform\` or \`tofu\`"** even for valid configs, whenever `playbook` (or `app`) is an **unknown** value.

Config validation runs **once per resource block with `for_each`/`count` values unknown** (before expansion), so `each.value.playbook` is unknown at that point. The validator treated unknown as "unset" and raised the error. Because `ValidateResource` runs during **plan/apply too** (not just `terraform validate`), this makes it impossible to drive templates from a `for_each` map at all — it fails even with an empty map.

## Root cause
```go
if !data.Playbook.IsNull() && !data.Playbook.IsUnknown() && data.Playbook.ValueString() != "" {
    return
}
```
When `playbook` is unknown, this early-return is skipped, so it falls through to the app check and errors. (Same for `app` sourced from `each.value`.)

## Fix
Defer validation when `playbook` or `app` is unknown — the concrete value is still validated once known (at apply):
```go
if data.Playbook.IsUnknown() || data.App.IsUnknown() {
    return
}
```

## Reproduce
```hcl
resource "semaphoreui_project_template" "this" {
  for_each       = var.templates            # any map (even {})
  project_id     = var.project_id
  name           = each.key
  playbook       = each.value.playbook
  repository_id  = var.repo_id
  inventory_id   = var.inv_id
  environment_id = var.env_id
}
```
`terraform plan` (not just validate) fails with the Missing playbook error. With this change it plans/applies normally, and a concrete empty/invalid playbook is still rejected as before.

Verified against provider 1.5.0 + SemaphoreUI 2.17. No behavior change for known values.